### PR TITLE
Change the link from java to python repository

### DIFF
--- a/api-client-python/index.rst
+++ b/api-client-python/index.rst
@@ -1,7 +1,7 @@
 The python client
 ---------------
 
-The `api-client-python <https://github.com/googlegenomics/api-client-java>`_ project
+The `api-client-python <https://github.com/googlegenomics/api-client-python>`_ project
 provides a simple genome browser that pulls data from the Genomics API.
 
 .. toctree::


### PR DESCRIPTION
I changed alink of the docs / api-client-python / index.rst , as long as I know it was wrongly pointing to the java repository instead to the python one